### PR TITLE
chore: use `cargo tag` for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 
 on:
   workflow_dispatch:
@@ -16,7 +16,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
 
 jobs:
   publish-dry-run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 
 on:
   workflow_dispatch:
@@ -16,6 +16,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   publish-dry-run:
@@ -37,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -47,23 +48,13 @@ jobs:
 
       - name: Install Rust Binaries
         run: |
-          cargo binstall -y --force cargo-edit
+          cargo binstall -y --force cargo-tag
 
-      - id: cargo-set-version
-        name: Set Version
-        run: cargo set-version --bump ${{ inputs.version }}
-
-      - name: Set Crate Version as Environment Variable
-        run: |
-          CARGO_TOML_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' Cargo.toml)
-          echo "CRATE_VERSION=$CARGO_TOML_VERSION" >> $GITHUB_ENV
-
-      - name: Create Commit
+      - name: Bump Version
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add .
-          git commit -m "chore: bump version to v$CRATE_VERSION"
+          echo "CRATE_VERSION=$(cargo tag -p=v ${{ inputs.version }})" >> $GITHUB_ENV
           git push origin main --follow-tags
 
       - name: Login to Crates.io
@@ -75,11 +66,11 @@ jobs:
         run: cargo publish
 
       - name: Create Release
-        id: create_release
-        uses: actions/github-script@v5
-        with:
-          script: |
-            await github.request(`POST /repos/${{ github.repository }}/releases`, {
-              tag_name: "v${{ env.CRATE_VERSION }}",
-              generate_release_notes: true
-            });
+        run: |
+          gh release create "$CRATE_VERSION" \
+            --title "$CRATE_VERSION" \
+            --draft=false \
+            --generate-notes \
+            --prerelease=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yaml` workflow to streamline the release process and modernize dependencies. The main improvements include updating the checkout action, simplifying the version bumping and tagging process, and switching to the GitHub CLI for release creation.

**Workflow modernization and dependency updates:**

* Updated the `actions/checkout` action from version 4 to version 6 to use the latest features and security updates.
* Added `id-token: write` to workflow permissions to support future authentication needs.

**Release process simplification:**

* Replaced the use of `cargo-edit` and manual version bumping with `cargo-tag` for streamlined version management, simplifying the steps for setting the crate version and tagging.
* Changed the release creation step to use the `gh release create` command instead of the `actions/github-script`, making the process more straightforward and leveraging the GitHub CLI.

**Minor adjustments:**

* Normalized the workflow name from `Release` to `release` for consistency.